### PR TITLE
Fixed arguments types in train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -13,7 +13,7 @@ from pose_augment import set_network_input_wh, set_network_scale
 
 def train():
     parser = argparse.ArgumentParser(description='Training codes for Openpose using Tensorflow')
-    parser.add_argument('--batch_size', type=str, default=10)
+    parser.add_argument('--batch_size', type=int, default=10)
     parser.add_argument('--continue_training', type=bool, default=False)
     parser.add_argument('--checkpoint_path', type=str, default='checkpoints/train/')
     parser.add_argument('--backbone_net_ckpt_path', type=str, default='checkpoints/vgg/vgg_19.ckpt')
@@ -31,14 +31,14 @@ def train():
     # parser.add_argument('--img_path_val', type=str,
     #                     default='/run/user/1000/gvfs/smb-share:server=192.168.1.2,share=data/yzy/dataset/'
     #                             'Realtime_Multi-Person_Pose_Estimation-master/training/dataset/COCO/images/val2017/')
-    parser.add_argument('--save_checkpoint_frequency', type=str, default=1000)
-    parser.add_argument('--save_summary_frequency', type=str, default=100)
-    parser.add_argument('--stage_num', type=str, default=6)
-    parser.add_argument('--hm_channels', type=str, default=19)
-    parser.add_argument('--paf_channels', type=str, default=38)
+    parser.add_argument('--save_checkpoint_frequency', type=int, default=1000)
+    parser.add_argument('--save_summary_frequency', type=int, default=100)
+    parser.add_argument('--stage_num', type=int, default=6)
+    parser.add_argument('--hm_channels', type=int, default=19)
+    parser.add_argument('--paf_channels', type=int, default=38)
     parser.add_argument('--input-width', type=int, default=368)
     parser.add_argument('--input-height', type=int, default=368)
-    parser.add_argument('--max_echos', type=str, default=5)
+    parser.add_argument('--max_echos', type=int, default=5)
     parser.add_argument('--use_bn', type=bool, default=False)
     parser.add_argument('--loss_func', type=str, default='l2')
     args = parser.parse_args()


### PR DESCRIPTION
I noticed some issues when I tried to use properties of your train.py script. In simple words, it denied my command-line parameters, because they were passed as strings. The reason lies within `parser.add_argument` lines, where some of the numeric parameters were described as `str` type, not `int`. I have made simple changes of making them `int` type.

If you are interested, I also paste errors I was getting with using base version of your script:

> $ python train.py --train_vgg False --annot_path datasets/coco_custom/annotations --img_path datasets/coco_custom/images --batch_size 1
> [2019-10-02 12:38:57,267] [train] [INFO] Namespace(annot_path='datasets/coco_custom/annotations', backbone_net_ckpt_path='checkpoints/vgg/vgg_19.ckpt', batch_size='1', checkpoint_path='checkpoints/train/', continue_training=False, hm_channels=19, img_path='datasets/coco_custom/images', input_height=368, input_width=368, loss_func='l2', max_echos=5, paf_channels=38, save_checkpoint_frequency=1000, save_summary_frequency=100, stage_num=6, train_vgg=True, use_bn=False)
> WARNING: Logging before flag parsing goes to stderr.
> I1002 12:38:57.267189 140594206218048 train.py:64] Namespace(annot_path='datasets/coco_custom/annotations', backbone_net_ckpt_path='checkpoints/vgg/vgg_19.ckpt', batch_size='1', checkpoint_path='checkpoints/train/', continue_training=False, hm_channels=19, img_path='datasets/coco_custom/images', input_height=368, input_width=368, loss_func='l2', max_echos=5, paf_channels=38, save_checkpoint_frequency=1000, save_summary_frequency=100, stage_num=6, train_vgg=True, use_bn=False)
> [2019-10-02 12:38:57,267] [train] [INFO] checkpoint_path: checkpoints/train/2019-10-2-12-38-57
> I1002 12:38:57.267535 140594206218048 train.py:65] checkpoint_path: checkpoints/train/2019-10-2-12-38-57
> [2019-10-02 12:38:57,269] [train] [INFO] initializing data loader...
> I1002 12:38:57.269855 140594206218048 train.py:76] initializing data loader...
> [2019-10-02 12:38:57,269] [pose_dataset] [INFO] dataflow img_path=datasets/coco_custom/images
> I1002 12:38:57.269975 140594206218048 pose_dataset.py:387] dataflow img_path=datasets/coco_custom/images
> loading annotations into memory...
> Done (t=0.00s)
> creating index...
> index created!
> [2019-10-02 12:38:57,270] [pose_dataset] [INFO] datasets/coco_custom/annotations dataset 1
> I1002 12:38:57.270261 140594206218048 pose_dataset.py:279] datasets/coco_custom/annotations dataset 1
> [1002 12:38:57 @parallel.py:231] [MultiProcessRunner] Will fork a dataflow more than one times. This assumes the datapoints are i.i.d.
> [1002 12:38:57 @argtools.py:146] WRN Starting a process with 'fork' method is not safe and may consume unnecessary extra CPU memory. Use 'forkserver/spawn' method (available after Py3.4) instead if you run into any issues. See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
> Traceback (most recent call last):
>   File "train.py", line 198, in <module>
>     train()
>   File "train.py", line 80, in train
>     df = get_dataflow_batch(args.annot_path, True, args.batch_size, img_path=args.img_path)
>   File "/home/asmox/AppDev/testing/unofficial-implement-of-openpose/pose_dataset.py", line 389, in get_dataflow_batch
>     ds = BatchData(ds, batchsize)
>   File "/home/asmox/AppDev/testing/venv-python3/lib/python3.6/site-packages/tensorpack/dataflow/common.py", line 96, in __init__
>     assert batch_size <= len(ds)
> TypeError: '<=' not supported between instances of 'str' and 'int'